### PR TITLE
fix: Add foojay resolver to fix Jitpack build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,4 +4,4 @@ plugins {
 }
 
 group = 'no.unit.nva'
-version = '0.5.11'
+version = '0.5.12'

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,6 @@ org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
 # Version of `nva-commons` used for version catalog and dependencies
 nvaCommonsVersion=2.8.1
+
+# Provides a toolchain download repository so Gradle can auto-provision the correct JDK
+foojayResolverVersion=1.0.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version "${foojayResolverVersion}"
+}
+
 dependencyResolutionManagement {
     repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
     repositories {


### PR DESCRIPTION
Adds a settings plugin that automatically downloads the correct JDK if it isn't already available (e.g. during Jitpack build).