### PR TITLE
fix: Configure publishing for subproject

### DIFF
--- a/build-logic/src/main/groovy/nva.doi-partner-data.java-conventions.gradle
+++ b/build-logic/src/main/groovy/nva.doi-partner-data.java-conventions.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'nva.java-conventions'
+    id 'maven-publish'
 }
 
 nva {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,3 @@
 plugins {
     id 'nva.doi-partner-data.root-module'
-    id 'maven-publish'
 }
-
-group = 'no.unit.nva'
-version = '0.5.12'

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,10 @@ org.gradle.warning.mode=all
 # Allow Gradle to use more memory than the default (needed for buildHealth command)
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
 
+# Maven coordinates applied to every module (root and subprojects) for published artifacts
+group=no.unit.nva
+version=0.5.13
+
 # Version of `nva-commons` used for version catalog and dependencies
 nvaCommonsVersion=2.8.1
 


### PR DESCRIPTION
Fixes more issues with publishing configuration introduced in https://github.com/BIBSYSDEV/nva-doi-partner-data/pull/33 which prevented Jitpack from building properly.